### PR TITLE
Fixed op.gg multisearch formatting bug

### DIFF
--- a/League_Account_Manager/MainWindow.xaml
+++ b/League_Account_Manager/MainWindow.xaml
@@ -7,7 +7,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
     mc:Ignorable="d"
-    Title="MainWindow" Height="800" Width="1400"
+    Title="League Account Manager" Height="800" Width="1400"
     AllowsTransparency="True"
     xmlns:notifications="clr-namespace:Notification.Wpf.Controls;assembly=Notification.Wpf"
     xmlns:Page="clr-namespace:League_Account_Manager.views"

--- a/League_Account_Manager/Window4.xaml.cs
+++ b/League_Account_Manager/Window4.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System.Windows;
+﻿    using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 

--- a/League_Account_Manager/views/Page1.xaml.cs
+++ b/League_Account_Manager/views/Page1.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -14,6 +14,7 @@ using Newtonsoft.Json.Linq;
 using NLog;
 using Notification.Wpf;
 using Application = FlaUI.Core.Application;
+
 
 namespace League_Account_Manager.views;
 
@@ -763,6 +764,11 @@ public partial class Page1 : Page
                             case "Loots":
                                 secondWindow = new Window4(selectedrow.Loot);
                                 break;
+                            default:  //otherwise will open op.gg could add this functionality only to "rank" or "riot id" column alternatively 
+                                var url = $"https:/www.op.gg/summoners/{RegionHelperUtil.RegionParser(selectedrow.server)}/{selectedrow.riotID.Replace("#", "-")}";
+                                OpenUrl(url);
+                                break;
+                                    
                         }
 
                         if (secondWindow != null)
@@ -812,6 +818,11 @@ public partial class Page1 : Page
     private async void SecondaryClient_OnClick(object sender, RoutedEventArgs e)
     {
         Process.Start(Settings.settingsloaded.LeaguePath, "--allow-multiple-clients");
+    }
+
+    private void OpenUrl(string url)
+    {
+        Process.Start(new ProcessStartInfo { FileName = url, UseShellExecute = true });
     }
 
     public class AccountList

--- a/League_Account_Manager/views/Page1.xaml.cs
+++ b/League_Account_Manager/views/Page1.xaml.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -14,7 +14,6 @@ using Newtonsoft.Json.Linq;
 using NLog;
 using Notification.Wpf;
 using Application = FlaUI.Core.Application;
-
 
 namespace League_Account_Manager.views;
 
@@ -764,11 +763,6 @@ public partial class Page1 : Page
                             case "Loots":
                                 secondWindow = new Window4(selectedrow.Loot);
                                 break;
-                            default:  //otherwise will open op.gg could add this functionality only to "rank" or "riot id" column alternatively 
-                                var url = $"https:/www.op.gg/summoners/{RegionHelperUtil.RegionParser(selectedrow.server)}/{selectedrow.riotID.Replace("#", "-")}";
-                                OpenUrl(url);
-                                break;
-                                    
                         }
 
                         if (secondWindow != null)
@@ -818,11 +812,6 @@ public partial class Page1 : Page
     private async void SecondaryClient_OnClick(object sender, RoutedEventArgs e)
     {
         Process.Start(Settings.settingsloaded.LeaguePath, "--allow-multiple-clients");
-    }
-
-    private void OpenUrl(string url)
-    {
-        Process.Start(new ProcessStartInfo { FileName = url, UseShellExecute = true });
     }
 
     public class AccountList

--- a/League_Account_Manager/views/Page1.xaml.cs
+++ b/League_Account_Manager/views/Page1.xaml.cs
@@ -15,6 +15,7 @@ using NLog;
 using Notification.Wpf;
 using Application = FlaUI.Core.Application;
 
+
 namespace League_Account_Manager.views;
 
 /// <summary>
@@ -763,6 +764,11 @@ public partial class Page1 : Page
                             case "Loots":
                                 secondWindow = new Window4(selectedrow.Loot);
                                 break;
+                            default:  //otherwise will open op.gg could add this functionality only to "rank" or "riot id" column alternatively 
+                                var url = $"https:/www.op.gg/summoners/{RegionHelperUtil.RegionParser(selectedrow.server)}/{selectedrow.riotID.Replace("#", "-")}";
+                                OpenUrl(url);
+                                break;
+                                    
                         }
 
                         if (secondWindow != null)
@@ -812,6 +818,11 @@ public partial class Page1 : Page
     private async void SecondaryClient_OnClick(object sender, RoutedEventArgs e)
     {
         Process.Start(Settings.settingsloaded.LeaguePath, "--allow-multiple-clients");
+    }
+
+    private void OpenUrl(string url)
+    {
+        Process.Start(new ProcessStartInfo { FileName = url, UseShellExecute = true });
     }
 
     public class AccountList

--- a/League_Account_Manager/views/Page1.xaml.cs
+++ b/League_Account_Manager/views/Page1.xaml.cs
@@ -764,7 +764,7 @@ public partial class Page1 : Page
                             case "Loots":
                                 secondWindow = new Window4(selectedrow.Loot);
                                 break;
-                            default:  //otherwise will open op.gg could add this functionality only to "rank" or "riot id" column alternatively 
+                            case "riotID":  //otherwise will open op.gg could add this functionality only to "rank" or "riot id" column alternatively 
                                 var url = $"https:/www.op.gg/summoners/{RegionHelperUtil.RegionParser(selectedrow.server)}/{selectedrow.riotID.Replace("#", "-")}";
                                 OpenUrl(url);
                                 break;

--- a/League_Account_Manager/views/Page4.xaml.cs
+++ b/League_Account_Manager/views/Page4.xaml.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Windows;
 using System.Windows.Controls;
 using Newtonsoft.Json.Linq;
@@ -175,22 +175,7 @@ public partial class Page4 : Page
             region = JObject.Parse(await GetResponseBody(resp));
             resp = await lcu.Connector("riot", "get", "/chat/v5/participants", "");
 
-            string region_parsed = region["region"].ToString().ToLower(); // Extract region and convert to lowercase
-
-            switch (region_parsed) // op.gg returns a 442 error otherwise
-            {
-                case "euw1": region_parsed = "euw"; break;
-                case "na1": region_parsed = "na"; break;
-                case "kr1": region_parsed = "kr"; break;
-                case "oc1": region_parsed = "oce"; break;
-                case "eun1": region_parsed = "eune"; break;
-                case "la1": region_parsed = "lan"; break;
-                case "la2": region_parsed = "las"; break;
-                case "ru1": region_parsed = "ru"; break;
-                case "tr1": region_parsed = "tr"; break;
-                case "jp1": region_parsed = "jp"; break;
-                    // If none of the cases match, leave region_parsed unchanged
-            }
+            string region_parsed = RegionHelperUtil.RegionParser(region["region"].ToString());
 
             var players = JObject.Parse(await GetResponseBody(resp));
             var url = $"https://www.op.gg/multisearch/{region_parsed}?summoners=";
@@ -249,6 +234,30 @@ public partial class Page4 : Page
     }
 }
 
+public static class RegionHelperUtil
+{
+    public static string RegionParser(string region)
+    {
+        var region_parsed = region.ToLower();
+
+        switch (region_parsed)
+        {
+            case "euw1": region_parsed = "euw"; break;
+            case "na1": region_parsed = "na"; break;
+            case "kr1": region_parsed = "kr"; break;
+            case "oc1": region_parsed = "oce"; break;
+            case "eun1": region_parsed = "eune"; break;
+            case "la1": region_parsed = "lan"; break;
+            case "la2": region_parsed = "las"; break;
+            case "ru1": region_parsed = "ru"; break;
+            case "tr1": region_parsed = "tr"; break;
+            case "jp1": region_parsed = "jp"; break;
+        }
+
+        return region_parsed;
+    }
+}
+    
 public class Gamestats
 {
     public double? Wins { get; set; }

--- a/League_Account_Manager/views/Page4.xaml.cs
+++ b/League_Account_Manager/views/Page4.xaml.cs
@@ -175,7 +175,22 @@ public partial class Page4 : Page
             region = JObject.Parse(await GetResponseBody(resp));
             resp = await lcu.Connector("riot", "get", "/chat/v5/participants", "");
 
-            string region_parsed = RegionHelperUtil.RegionParser(region["region"].ToString());
+            string region_parsed = region["region"].ToString().ToLower(); // Extract region and convert to lowercase
+
+            switch (region_parsed) // op.gg returns a 442 error otherwise
+            {
+                case "euw1": region_parsed = "euw"; break;
+                case "na1": region_parsed = "na"; break;
+                case "kr1": region_parsed = "kr"; break;
+                case "oc1": region_parsed = "oce"; break;
+                case "eun1": region_parsed = "eune"; break;
+                case "la1": region_parsed = "lan"; break;
+                case "la2": region_parsed = "las"; break;
+                case "ru1": region_parsed = "ru"; break;
+                case "tr1": region_parsed = "tr"; break;
+                case "jp1": region_parsed = "jp"; break;
+                    // If none of the cases match, leave region_parsed unchanged
+            }
 
             var players = JObject.Parse(await GetResponseBody(resp));
             var url = $"https://www.op.gg/multisearch/{region_parsed}?summoners=";
@@ -234,30 +249,6 @@ public partial class Page4 : Page
     }
 }
 
-public static class RegionHelperUtil
-{
-    public static string RegionParser(string region)
-    {
-        var region_parsed = region.ToLower();
-
-        switch (region_parsed)
-        {
-            case "euw1": region_parsed = "euw"; break;
-            case "na1": region_parsed = "na"; break;
-            case "kr1": region_parsed = "kr"; break;
-            case "oc1": region_parsed = "oce"; break;
-            case "eun1": region_parsed = "eune"; break;
-            case "la1": region_parsed = "lan"; break;
-            case "la2": region_parsed = "las"; break;
-            case "ru1": region_parsed = "ru"; break;
-            case "tr1": region_parsed = "tr"; break;
-            case "jp1": region_parsed = "jp"; break;
-        }
-
-        return region_parsed;
-    }
-}
-    
 public class Gamestats
 {
     public double? Wins { get; set; }

--- a/League_Account_Manager/views/Page4.xaml.cs
+++ b/League_Account_Manager/views/Page4.xaml.cs
@@ -175,22 +175,7 @@ public partial class Page4 : Page
             region = JObject.Parse(await GetResponseBody(resp));
             resp = await lcu.Connector("riot", "get", "/chat/v5/participants", "");
 
-            string region_parsed = region["region"].ToString().ToLower(); // Extract region and convert to lowercase
-
-            switch (region_parsed) // op.gg returns a 442 error otherwise
-            {
-                case "euw1": region_parsed = "euw"; break;
-                case "na1": region_parsed = "na"; break;
-                case "kr1": region_parsed = "kr"; break;
-                case "oc1": region_parsed = "oce"; break;
-                case "eun1": region_parsed = "eune"; break;
-                case "la1": region_parsed = "lan"; break;
-                case "la2": region_parsed = "las"; break;
-                case "ru1": region_parsed = "ru"; break;
-                case "tr1": region_parsed = "tr"; break;
-                case "jp1": region_parsed = "jp"; break;
-                    // If none of the cases match, leave region_parsed unchanged
-            }
+            string region_parsed = RegionHelperUtil.RegionParser(region["region"].ToString());
 
             var players = JObject.Parse(await GetResponseBody(resp));
             var url = $"https://www.op.gg/multisearch/{region_parsed}?summoners=";
@@ -249,6 +234,30 @@ public partial class Page4 : Page
     }
 }
 
+public static class RegionHelperUtil
+{
+    public static string RegionParser(string region)
+    {
+        var region_parsed = region.ToLower();
+
+        switch (region_parsed)
+        {
+            case "euw1": region_parsed = "euw"; break;
+            case "na1": region_parsed = "na"; break;
+            case "kr1": region_parsed = "kr"; break;
+            case "oc1": region_parsed = "oce"; break;
+            case "eun1": region_parsed = "eune"; break;
+            case "la1": region_parsed = "lan"; break;
+            case "la2": region_parsed = "las"; break;
+            case "ru1": region_parsed = "ru"; break;
+            case "tr1": region_parsed = "tr"; break;
+            case "jp1": region_parsed = "jp"; break;
+        }
+
+        return region_parsed;
+    }
+}
+    
 public class Gamestats
 {
     public double? Wins { get; set; }

--- a/League_Account_Manager/views/Page4.xaml.cs
+++ b/League_Account_Manager/views/Page4.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Windows;
 using System.Windows.Controls;
 using Newtonsoft.Json.Linq;
@@ -174,8 +174,26 @@ public partial class Page4 : Page
             var resp = await lcu.Connector("riot", "get", "/riotclient/get_region_locale", "");
             region = JObject.Parse(await GetResponseBody(resp));
             resp = await lcu.Connector("riot", "get", "/chat/v5/participants", "");
+
+            string region_parsed = region["region"].ToString().ToLower(); // Extract region and convert to lowercase
+
+            switch (region_parsed) // op.gg returns a 442 error otherwise
+            {
+                case "euw1": region_parsed = "euw"; break;
+                case "na1": region_parsed = "na"; break;
+                case "kr1": region_parsed = "kr"; break;
+                case "oc1": region_parsed = "oce"; break;
+                case "eun1": region_parsed = "eune"; break;
+                case "la1": region_parsed = "lan"; break;
+                case "la2": region_parsed = "las"; break;
+                case "ru1": region_parsed = "ru"; break;
+                case "tr1": region_parsed = "tr"; break;
+                case "jp1": region_parsed = "jp"; break;
+                    // If none of the cases match, leave region_parsed unchanged
+            }
+
             var players = JObject.Parse(await GetResponseBody(resp));
-            var url = $"https://www.op.gg/multisearch/{region["region"]}?summoners=";
+            var url = $"https://www.op.gg/multisearch/{region_parsed}?summoners=";
 
             foreach (var player in players["participants"])
             {


### PR DESCRIPTION
I've only tested for oce/oc1 but I believe this problem might persist on all regions.

it basically turns

https://www.op.gg/multisearch/OC1?summoners=apple%23OCE (which returns some HTTP error)
into -> https://www.op.gg/multisearch/oce?summoners=apple%23OCE (without HTTP error :D)