### PR TITLE
Fix login typing broken by Riot Client v136 (UIA tree removed)

### DIFF
--- a/League_Account_Manager/Misc/LoginTokenManager.cs
+++ b/League_Account_Manager/Misc/LoginTokenManager.cs
@@ -478,167 +478,38 @@ public static class LoginTokenManager
 
     private static async Task<bool> AutomateLoginAsync(string riotProcessName, string username, string password)
     {
-        var attempts = 0;
-        while (attempts < 500)
+        var hwnd = await RiotUiLogin.WaitForLoginWindowAsync();
+        if (hwnd == IntPtr.Zero)
         {
-            attempts++;
-            DebugConsole.WriteLine($"[Token] Login automation attempt {attempts}");
-            try
-            {
-                var app = Application.Attach(riotProcessName);
-                using var automation = new UIA3Automation();
-                var window = app.GetMainWindow(automation);
-                var content = window.FindFirstDescendant(cf => cf.ByClassName("Chrome_RenderWidgetHostHWND"));
-                if (content == null)
-                {
-                    DebugConsole.WriteLine("[Token] Could not find content window");
-                    await Task.Delay(300);
-                    continue;
-                }
-
-                var usernameField = content.FindFirstDescendant(cf => cf.ByAutomationId("username"))?.AsTextBox();
-                var passwordField = content.FindFirstDescendant(cf => cf.ByAutomationId("password"))?.AsTextBox();
-                var rememberBox = content.FindFirstDescendant(cf => cf.ByAutomationId("remember-me"))?.AsCheckBox() ??
-                                  content.FindFirstDescendant(cf => cf.ByControlType(ControlType.CheckBox))
-                                      ?.AsCheckBox();
-                if (rememberBox == null)
-                    DebugConsole.WriteLine(
-                        "[Token] Remember-me checkbox not found by automationId; using first checkbox");
-
-                var siblings = content.FindAllChildren();
-                AutomationElement? signInElement = null;
-                if (rememberBox != null)
-                {
-                    var count = Array.IndexOf(siblings, rememberBox) + 1;
-                    while (siblings.Length >= count)
-                    {
-                        var maybeButton = siblings[count++].AsButton();
-                        if (maybeButton != null && maybeButton.ControlType == ControlType.Button)
-                        {
-                            signInElement = maybeButton;
-                            break;
-                        }
-                    }
-                }
-
-                signInElement ??= siblings
-                    .Select(x => x.AsButton())
-                    .FirstOrDefault(b => b != null && b.ControlType == ControlType.Button);
-
-                if (usernameField == null || passwordField == null || signInElement == null)
-                {
-                    DebugConsole.WriteLine("[Token] Missing username/password/sign-in controls");
-                    await Task.Delay(300);
-                    continue;
-                }
-
-                usernameField.Text = username;
-                passwordField.Text = password;
-
-                if (rememberBox != null && rememberBox.IsChecked != true)
-                    try
-                    {
-                        rememberBox.Focus();
-                        rememberBox.Patterns.Toggle.Pattern.Toggle();
-                        await Task.Delay(100);
-                        rememberBox.IsChecked = true;
-                        DebugConsole.WriteLine("[Token] Enabled remember-me checkbox via toggle");
-                    }
-                    catch
-                    {
-                        try
-                        {
-                            rememberBox.IsChecked = true;
-                            DebugConsole.WriteLine("[Token] Enabled remember-me checkbox via IsChecked");
-                        }
-                        catch
-                        {
-                        }
-                    }
-
-                while (!signInElement.IsEnabled)
-                {
-                    DebugConsole.WriteLine("[Token] Waiting for sign-in button to enable");
-                    await Task.Delay(200);
-                }
-
-                await Task.Delay(1000);
-                signInElement.AsButton()?.Invoke();
-                DebugConsole.WriteLine("[Token] Sign-in invoked");
-
-                await Task.Delay(500);
-
-                var restartLogin = false;
-                var cancelLogin = false;
-                var loginErrorChecks = 0;
-
-                while (true)
-                {
-                    try
-                    {
-                        var loginError = window.FindFirstDescendant(cf =>
-                            cf.ByControlType(ControlType.ToolTip).And(cf.ByName("Login error")));
-                        if (loginError != null)
-                        {
-                            loginErrorChecks++;
-                            DebugConsole.WriteLine($"[Token] Login error tooltip detected (check {loginErrorChecks})");
-
-                            if (loginErrorChecks >= 2)
-                            {
-                                cancelLogin = true;
-                                break;
-                            }
-
-                            restartLogin = true;
-                            break;
-                        }
-                    }
-                    catch
-                    {
-                    }
-
-                    var resp = await Lcu.Connector("riot", "get", "/eula/v1/agreement/acceptance", "");
-                    string status = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    DebugConsole.WriteLine($"[Token] EULA status: {status}");
-                    if (status == "\"Accepted\"")
-                        break;
-                    if (status == "\"AcceptanceRequired\"")
-                    {
-                        DebugConsole.WriteLine("[Token] Accepting EULA");
-                        await Lcu.Connector("riot", "put", "/eula/v1/agreement/acceptance", "");
-                        await Task.Delay(200);
-                    }
-                    else
-                    {
-                        await Task.Delay(500);
-                    }
-                }
-
-                if (cancelLogin)
-                {
-                    DebugConsole.WriteLine("[Token] Canceling login after repeated errors");
-                    return false;
-                }
-
-                if (restartLogin)
-                {
-                    DebugConsole.WriteLine("[Token] Restarting login flow after error");
-                    await Task.Delay(500);
-                    continue;
-                }
-
-                return true;
-            }
-            catch (Exception ex)
-            {
-                Logger.Warn(ex, "Retrying login automation for token generation");
-                DebugConsole.WriteLine($"[Token] Login automation error: {ex.Message}");
-                await Task.Delay(500);
-            }
+            DebugConsole.WriteLine("[Token] Riot Client window never appeared");
+            return false;
         }
 
-        DebugConsole.WriteLine("[Token] Exhausted login automation attempts");
+        // give the sign-in page time to render inside the window
+        await Task.Delay(4000);
 
+        var checkedStaySignedIn = false;
+        for (var attempt = 1; attempt <= 3; attempt++)
+        {
+            DebugConsole.WriteLine($"[Token] Typing credentials (attempt {attempt})");
+            // the remember-me box is a blind toggle and the form starts
+            // unchecked, so only tick it once
+            if (await RiotUiLogin.EnterCredentialsAsync(username, password, !checkedStaySignedIn))
+                checkedStaySignedIn = true;
+            else
+                await Task.Delay(2000);
+
+            if (await RiotUiLogin.WaitForAuthAsync(TimeSpan.FromSeconds(20)))
+                return true;
+        }
+
+        // possibly a captcha the user has to solve; wait while the client runs
+        DebugConsole.WriteLine("[Token] Login not confirmed yet; waiting (captcha may need the user)");
+        while (RiotUiLogin.RiotClientRunning)
+            if (await RiotUiLogin.WaitForAuthAsync(TimeSpan.FromSeconds(5)))
+                return true;
+
+        DebugConsole.WriteLine("[Token] Riot Client closed before login completed");
         return false;
     }
 

--- a/League_Account_Manager/Misc/RiotUiLogin.cs
+++ b/League_Account_Manager/Misc/RiotUiLogin.cs
@@ -1,0 +1,385 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using FlaUI.Core.Input;
+
+namespace League_Account_Manager.Misc;
+
+/// <summary>
+///     Enters credentials into the Riot Client sign-in form with real
+///     (SendInput) keyboard and mouse events after bringing the client window
+///     to the foreground.
+///     Recent Riot Client builds (CEF, v136+) no longer expose a UI Automation
+///     tree — there is no Chrome_RenderWidgetHostHWND child and no elements
+///     with the "username"/"password" automation ids — so the old FlaUI
+///     element lookup found nothing and typed nothing. Posted window messages
+///     (WM_CHAR) are also dropped inconsistently by this client, so real input
+///     against the focused window is the only dependable path.
+/// </summary>
+internal static class RiotUiLogin
+{
+    private const int SwRestore = 9;
+
+    // Sign-in form layout measured in a 1536x864 window; scaled to the actual
+    // window size before use.
+    private const double RefWidth = 1536;
+    private const double RefHeight = 864;
+    private static readonly (double X, double Y) UsernameField = (200, 281);
+    private static readonly (double X, double Y) PasswordField = (200, 345);
+    private static readonly (double X, double Y) StaySignedInBox = (64, 453);
+
+    [DllImport("user32.dll")]
+    private static extern bool SetForegroundWindow(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr GetForegroundWindow();
+
+    [DllImport("user32.dll")]
+    private static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint processId);
+
+    [DllImport("kernel32.dll")]
+    private static extern uint GetCurrentThreadId();
+
+    [DllImport("user32.dll")]
+    private static extern bool AttachThreadInput(uint idAttach, uint idAttachTo, bool fAttach);
+
+    [DllImport("user32.dll")]
+    private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+
+    [DllImport("user32.dll")]
+    private static extern bool IsIconic(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    private static extern bool GetWindowRect(IntPtr hWnd, out Rect rect);
+
+    public static bool RiotClientRunning =>
+        Process.GetProcessesByName("Riot Client").Length != 0 ||
+        Process.GetProcessesByName("RiotClientUx").Length != 0;
+
+    /// <summary>
+    ///     Waits for a Riot Client process that owns a visible top-level window
+    ///     and returns that window's current handle. CEF spawns several
+    ///     subprocesses all named "Riot Client" and recreates its window during
+    ///     startup, so the handle must be resolved fresh before every use —
+    ///     never cached across attempts.
+    /// </summary>
+    public static async Task<IntPtr> WaitForLoginWindowAsync(int timeoutMs = 60000)
+    {
+        var sw = Stopwatch.StartNew();
+        while (sw.ElapsedMilliseconds < timeoutMs)
+        {
+            var proc = Process.GetProcessesByName("Riot Client")
+                .Concat(Process.GetProcessesByName("RiotClientUx"))
+                .FirstOrDefault(p => p.MainWindowHandle != IntPtr.Zero);
+            if (proc != null) return proc.MainWindowHandle;
+            await Task.Delay(200);
+        }
+
+        return IntPtr.Zero;
+    }
+
+    /// <summary>
+    ///     Brings the Riot window to the foreground, clicks each field, clears
+    ///     it, types the credential, optionally ticks "Stay signed in", and
+    ///     submits with Enter. Returns false when the window could not be
+    ///     focused (or disappeared) — callers should retry after a delay.
+    ///     The stay-signed-in click is a blind toggle and the form starts
+    ///     unchecked, so only pass true on the first attempt.
+    /// </summary>
+    public static async Task<bool> EnterCredentialsAsync(string? username, string? password,
+        bool staySignedIn = false, bool submit = true)
+    {
+        // the window handle churns during client startup; always resolve fresh
+        var hwnd = await WaitForLoginWindowAsync(10000);
+        if (hwnd == IntPtr.Zero) return false;
+
+        if (!await ForceForegroundAsync(hwnd))
+        {
+            DebugConsole.WriteLine("[RiotUiLogin] Could not bring Riot Client window to foreground");
+            return false;
+        }
+
+        if (!GetWindowRect(hwnd, out var rect) || rect.Right - rect.Left < 100) return false;
+
+        ClickAt(rect, UsernameField);
+        await Task.Delay(250);
+        ClearFocusedField();
+        TypeText(username ?? "");
+        await Task.Delay(150);
+
+        ClickAt(rect, PasswordField);
+        await Task.Delay(250);
+        ClearFocusedField();
+        TypeText(password ?? "");
+        await Task.Delay(150);
+
+        if (staySignedIn)
+        {
+            ClickAt(rect, StaySignedInBox);
+            await Task.Delay(250);
+        }
+
+        if (submit)
+        {
+            // Enter submits the form while focus is in a text field
+            ClickAt(rect, PasswordField);
+            await Task.Delay(250);
+            PressKey(VkReturn);
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    ///     Polls the Riot Client EULA endpoint until it reports a logged-in
+    ///     state ("Accepted" or "AcceptanceRequired", which is accepted
+    ///     automatically). Returns false once the timeout elapses — e.g. when
+    ///     the page was not ready yet or a captcha is waiting for the user.
+    /// </summary>
+    public static async Task<bool> WaitForAuthAsync(TimeSpan timeout)
+    {
+        var sw = Stopwatch.StartNew();
+        while (sw.Elapsed < timeout)
+        {
+            try
+            {
+                var resp = await Lcu.Connector("riot", "get", "/eula/v1/agreement/acceptance", "");
+                var status = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (status == "\"Accepted\"") return true;
+                if (status == "\"AcceptanceRequired\"")
+                {
+                    DebugConsole.WriteLine("[RiotUiLogin] Accepting EULA");
+                    await Lcu.Connector("riot", "put", "/eula/v1/agreement/acceptance", "");
+                    return true;
+                }
+            }
+            catch
+            {
+                // client not ready to answer yet
+            }
+
+            await Task.Delay(500);
+        }
+
+        return false;
+    }
+
+    private static async Task<bool> ForceForegroundAsync(IntPtr hwnd)
+    {
+        for (var attempt = 0; attempt < 5; attempt++)
+        {
+            if (GetForegroundWindow() == hwnd) return true;
+
+            if (IsIconic(hwnd)) ShowWindow(hwnd, SwRestore);
+
+            // attach to the current foreground thread so Windows lets us hand
+            // the foreground over even when another app currently holds it
+            var foreground = GetForegroundWindow();
+            var foregroundThread = GetWindowThreadProcessId(foreground, out _);
+            var ourThread = GetCurrentThreadId();
+            var attached = foregroundThread != ourThread &&
+                           AttachThreadInput(ourThread, foregroundThread, true);
+            try
+            {
+                // a benign key tap marks our process as "recently received
+                // input", which also satisfies the foreground-lock rules
+                PressKey(VkMenu);
+                SetForegroundWindow(hwnd);
+            }
+            finally
+            {
+                if (attached) AttachThreadInput(ourThread, foregroundThread, false);
+            }
+
+            await Task.Delay(250);
+            if (GetForegroundWindow() == hwnd) return true;
+        }
+
+        return GetForegroundWindow() == hwnd;
+    }
+
+    private static void ClickAt(Rect rect, (double X, double Y) refPoint)
+    {
+        var width = rect.Right - rect.Left;
+        var height = rect.Bottom - rect.Top;
+        var x = rect.Left + (int)(refPoint.X * width / RefWidth);
+        var y = rect.Top + (int)(refPoint.Y * height / RefHeight);
+        Mouse.MoveTo(x, y);
+        Mouse.Click();
+    }
+
+    private static void ClearFocusedField()
+    {
+        // Ctrl+A, Delete — all as scancode events
+        SendScan(ScanFromVk(VkControl), false);
+        Thread.Sleep(KeyDelayMs);
+        SendScan(ScanFromVk(VkA), false);
+        Thread.Sleep(KeyDelayMs);
+        SendScan(ScanFromVk(VkA), true);
+        Thread.Sleep(KeyDelayMs);
+        SendScan(ScanFromVk(VkControl), true);
+        Thread.Sleep(KeyDelayMs);
+        PressKey(VkDelete);
+        Thread.Sleep(KeyDelayMs);
+    }
+
+    // ----- scancode keyboard input -----
+    // Characters are sent as hardware scancode events (KEYEVENTF_SCANCODE)
+    // resolved through the active keyboard layout, with a real Shift press
+    // around characters that need it — identical to physical typing. The
+    // KEYEVENTF_UNICODE path is used only for characters the layout cannot
+    // produce.
+
+    private const int KeyDelayMs = 25;
+
+    private const ushort VkReturn = 0x0D;
+    private const ushort VkControl = 0x11;
+    private const ushort VkMenu = 0x12;
+    private const ushort VkDelete = 0x2E;
+    private const ushort VkA = 0x41;
+
+    private const uint InputKeyboard = 1;
+    private const uint KeyEventFExtended = 0x01;
+    private const uint KeyEventFKeyUp = 0x02;
+    private const uint KeyEventFUnicode = 0x04;
+    private const uint KeyEventFScancode = 0x08;
+    private const uint MapVkToVsc = 0;
+
+    // extended keys live in the e0-prefixed scancode set
+    private static readonly ushort[] ExtendedVks = { 0x2E /*DEL*/, 0x23 /*END*/, 0x24 /*HOME*/, 0x21, 0x22, 0x25, 0x26, 0x27, 0x28, 0x2D };
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern uint SendInput(uint nInputs, Input[] pInputs, int cbSize);
+
+    [DllImport("user32.dll")]
+    private static extern short VkKeyScanW(char ch);
+
+    [DllImport("user32.dll")]
+    private static extern uint MapVirtualKeyW(uint uCode, uint uMapType);
+
+    private static void TypeText(string text)
+    {
+        foreach (var c in text)
+        {
+            var vkScan = VkKeyScanW(c);
+            if (vkScan == -1)
+            {
+                // not producible on the active layout — unicode fallback
+                SendUnicode(c);
+                Thread.Sleep(KeyDelayMs);
+                continue;
+            }
+
+            var vk = (ushort)(vkScan & 0xFF);
+            var needShift = (vkScan & 0x100) != 0;
+            var scan = ScanFromVk(vk);
+            if (scan == 0)
+            {
+                SendUnicode(c);
+                Thread.Sleep(KeyDelayMs);
+                continue;
+            }
+
+            if (needShift)
+            {
+                SendScan(0x2A, false); // left shift
+                Thread.Sleep(KeyDelayMs);
+            }
+
+            SendScan(scan, false, IsExtended(vk));
+            Thread.Sleep(KeyDelayMs);
+            SendScan(scan, true, IsExtended(vk));
+
+            if (needShift)
+            {
+                Thread.Sleep(KeyDelayMs);
+                SendScan(0x2A, true);
+            }
+
+            Thread.Sleep(KeyDelayMs);
+        }
+    }
+
+    private static void PressKey(ushort vk)
+    {
+        var scan = ScanFromVk(vk);
+        SendScan(scan, false, IsExtended(vk));
+        Thread.Sleep(KeyDelayMs);
+        SendScan(scan, true, IsExtended(vk));
+        Thread.Sleep(KeyDelayMs);
+    }
+
+    private static ushort ScanFromVk(ushort vk)
+    {
+        return (ushort)MapVirtualKeyW(vk, MapVkToVsc);
+    }
+
+    private static bool IsExtended(ushort vk)
+    {
+        return ExtendedVks.Contains(vk);
+    }
+
+    private static void SendScan(ushort scan, bool keyUp, bool extended = false)
+    {
+        var flags = KeyEventFScancode | (keyUp ? KeyEventFKeyUp : 0) | (extended ? KeyEventFExtended : 0);
+        var input = new Input
+        {
+            Type = InputKeyboard,
+            Data = { Keyboard = new KeyboardInput { Scan = scan, Flags = flags } }
+        };
+        SendInput(1, new[] { input }, Marshal.SizeOf<Input>());
+    }
+
+    private static void SendUnicode(char c)
+    {
+        var down = new Input
+        {
+            Type = InputKeyboard,
+            Data = { Keyboard = new KeyboardInput { Scan = c, Flags = KeyEventFUnicode } }
+        };
+        var up = new Input
+        {
+            Type = InputKeyboard,
+            Data = { Keyboard = new KeyboardInput { Scan = c, Flags = KeyEventFUnicode | KeyEventFKeyUp } }
+        };
+        SendInput(2, new[] { down, up }, Marshal.SizeOf<Input>());
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct KeyboardInput
+    {
+        public ushort Vk;
+        public ushort Scan;
+        public uint Flags;
+        public uint Time;
+        public IntPtr ExtraInfo;
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    private struct InputUnion
+    {
+        [FieldOffset(0)] public KeyboardInput Keyboard;
+        [FieldOffset(0)] public MouseInputPadding Mouse;
+    }
+
+    // ensures the union is at least as large as MOUSEINPUT, which the OS expects
+    [StructLayout(LayoutKind.Sequential)]
+    private struct MouseInputPadding
+    {
+        public int Dx, Dy;
+        public uint MouseData, Flags, Time;
+        public IntPtr ExtraInfo;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct Input
+    {
+        public uint Type;
+        public InputUnion Data;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct Rect
+    {
+        public int Left, Top, Right, Bottom;
+    }
+}

--- a/League_Account_Manager/views/Accounts.xaml.cs
+++ b/League_Account_Manager/views/Accounts.xaml.cs
@@ -1572,209 +1572,54 @@ public partial class Accounts : Page
                 if (num == 80) return;
             }
 
-            while (true)
-                try
+            var hwnd = await RiotUiLogin.WaitForLoginWindowAsync();
+            if (hwnd == IntPtr.Zero)
+            {
+                DebugConsole.WriteLine("[Accounts] Riot Client window never appeared", ConsoleColor.Yellow);
+                return;
+            }
+
+            // give the sign-in page time to render inside the window
+            await Task.Delay(4000);
+
+            var loggedIn = false;
+            for (var attempt = 1; attempt <= 3 && !loggedIn; attempt++)
+            {
+                DebugConsole.WriteLine($"[Accounts] Typing credentials (attempt {attempt})");
+                if (!await RiotUiLogin.EnterCredentialsAsync(SelectedUsername, SelectedPassword))
                 {
-                    var restartLogin = false;
-                    var cancelLogin = false;
-                    var app = Application.Attach(riotval);
-
-                    using (var automation = new UIA3Automation())
-                    {
-                        AutomationElement window = app.GetMainWindow(automation);
-                        var riotcontent =
-                            window.FindFirstDescendant(cf => cf.ByClassName("Chrome_RenderWidgetHostHWND"));
-
-
-                        var usernameField = riotcontent.FindFirstDescendant(cf => cf.ByAutomationId("username"))
-                            .AsTextBox();
-                        if (usernameField == null) throw new Exception("Username field not found");
-
-
-                        // Find the password field
-                        var passwordField = riotcontent.FindFirstDescendant(cf => cf.ByAutomationId("password"))
-                            .AsTextBox();
-                        if (passwordField == null) throw new Exception("Password field not found");
-
-
-                        var checkbox = riotcontent.FindFirstDescendant(cf => cf.ByControlType(ControlType.CheckBox));
-                        if (riotcontent == null) throw new Exception("Riot content not found");
-                        if (checkbox == null) throw new Exception("Checkbox field not found");
-
-                        var siblings = riotcontent.FindAllChildren();
-                        if (checkbox.Parent == null) throw new Exception("Checkbox parent not found");
-                        DebugConsole.WriteLine(siblings.Length.ToString());
-                        var count = Array.IndexOf(siblings, checkbox) + 1;
-                        if (siblings.Length <= count) throw new Exception("Not enough siblings found for the checkbox");
-                        dynamic signInElement = null;
-                        while (siblings.Length >= count)
-                        {
-                            signInElement = siblings[count++].AsButton();
-
-                            DebugConsole.WriteLine($"Found checkbox: {checkbox.Name}");
-                            DebugConsole.WriteLine($"Found siblings count: {siblings.Length}");
-
-                            if (signInElement.ControlType != ControlType.Button) continue;
-                            break;
-                        }
-
-                        usernameField.Text = SelectedUsername;
-                        passwordField.Text = SelectedPassword;
-                        if (signInElement != null)
-                        {
-                            while (!signInElement.IsEnabled) await Task.Delay(200);
-                            signInElement.Invoke();
-
-                            // brief pause to allow any login error tooltip to appear
-                            await Task.Delay(500);
-
-                            while (true)
-                            {
-                                try
-                                {
-                                    // look for a Tooltip with name "Login error" in the same window
-                                    var loginError = window.FindFirstDescendant(cf =>
-                                        cf.ByControlType(ControlType.ToolTip).And(cf.ByName("Login error")));
-                                    if (loginError != null)
-                                    {
-                                        loginAttempts++;
-
-                                        var errorText = string.Empty;
-                                        try
-                                        {
-                                            errorText = loginError
-                                                .FindFirstDescendant(cf => cf.ByControlType(ControlType.Text)
-                                                    .And(cf.ByName(
-                                                        "Your login credentials don't match an account in our system.")))
-                                                ?.Name;
-                                        }
-                                        catch
-                                        {
-                                        }
-
-                                        if (string.IsNullOrWhiteSpace(errorText))
-                                        {
-                                            try
-                                            {
-                                                errorText = loginError.Name;
-                                            }
-                                            catch
-                                            {
-                                            }
-
-                                            if (string.IsNullOrWhiteSpace(errorText))
-                                                try
-                                                {
-                                                    errorText = loginError.Properties.Name.Value;
-                                                }
-                                                catch
-                                                {
-                                                }
-                                        }
-
-                                        var invalidCreds = !string.IsNullOrWhiteSpace(errorText) &&
-                                                           errorText.Contains(
-                                                               "Your login credentials don't match an account in our system.",
-                                                               StringComparison.OrdinalIgnoreCase);
-
-                                        if (invalidCreds)
-                                        {
-                                            // Mark account as invalid login
-                                            var existingNote = ActualAccountlists?.FindLast(x =>
-                                                x.username == SelectedUsername && x.password == SelectedPassword)?.note;
-                                            ActualAccountlists?.RemoveAll(x =>
-                                                x.username == SelectedUsername && x.password == SelectedPassword);
-                                            ActualAccountlists?.Add(new Utils.AccountList
-                                            {
-                                                username = SelectedUsername,
-                                                password = SelectedPassword,
-                                                riotID = "Invalid Login",
-                                                level = 0,
-                                                server = "INVALID",
-                                                be = 0,
-                                                rp = 0,
-                                                rank = "Invalid Login",
-                                                champions = "",
-                                                Champions = 0,
-                                                skins = "",
-                                                Skins = 0,
-                                                Loot = "",
-                                                Loots = 0,
-                                                rank2 = "Invalid Login",
-                                                note = existingNote
-                                            });
-
-                                            // persist immediately
-                                            await AccountFileStore.SaveAsync(AccountFileStore.GetAccountsFilePath(),
-                                                ActualAccountlists, config);
-
-                                            // update UI and stop login flow
-                                            Dispatcher.Invoke(() =>
-                                            {
-                                                AccountsDataGrid.ItemsSource = null;
-                                                AccountsDataGrid.ItemsSource = ActualAccountlists;
-                                                AccountsDataGrid.Items.Refresh();
-                                            });
-
-                                            return; // pause/stop login processing
-                                        }
-
-                                        if (loginAttempts >= 3)
-                                        {
-                                            cancelLogin = true;
-                                            break;
-                                        }
-
-                                        restartLogin = true;
-                                        break;
-                                    }
-                                }
-                                catch
-                                {
-                                }
-
-                                var resp = await Lcu.Connector("riot", "get", "/eula/v1/agreement/acceptance", "");
-                                string status = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
-                                DebugConsole.WriteLine($"[Accounts] EULA status: {status}");
-                                if (status == "\"Accepted\"") break;
-                                if (status == "\"AcceptanceRequired\"")
-                                {
-                                    await Lcu.Connector("riot", "put", "/eula/v1/agreement/acceptance", "");
-                                    await Task.Delay(200);
-                                }
-                                else
-                                {
-                                    await Task.Delay(500);
-                                }
-                            }
-
-                            if (cancelLogin) return;
-
-                            if (restartLogin)
-                            {
-                                await Task.Delay(500);
-                                continue;
-                            }
-
-                            await Lcu.Connector("riot", "post",
-                                "/product-launcher/v1/products/league_of_legends/patchlines/live", "");
-                            WaitForSummonerReadyAsync();
-                            break;
-                        }
-
-                        await Task.Delay(500);
-                    }
+                    await Task.Delay(2000);
+                    continue;
                 }
-                catch (Exception ex)
+
+                loggedIn = await RiotUiLogin.WaitForAuthAsync(TimeSpan.FromSeconds(20));
+            }
+
+            // still not authenticated: a captcha or login error may need the user;
+            // keep waiting while the client is running instead of retyping over it
+            while (!loggedIn)
+            {
+                if (!RiotUiLogin.RiotClientRunning)
                 {
-                    _logger.Warn(ex, "Transient error during login automation");
-                    DebugConsole.WriteLine($"[Accounts] Login automation retry: {ex.Message}", ConsoleColor.Yellow);
-                    await Task.Delay(200);
+                    DebugConsole.WriteLine("[Accounts] Riot Client closed before login completed",
+                        ConsoleColor.Yellow);
+                    return;
                 }
+
+                loggedIn = await RiotUiLogin.WaitForAuthAsync(TimeSpan.FromSeconds(5));
+            }
+
+            await Lcu.Connector("riot", "post",
+                "/product-launcher/v1/products/league_of_legends/patchlines/live", "");
+            WaitForSummonerReadyAsync();
         }
         catch (Exception exception)
         {
             LogManager.GetCurrentClassLogger().Error(exception, "Error loading data");
+            Notif.notificationManager.Show("Error", $"Login failed: {exception.Message}",
+                NotificationType.Notification,
+                "WindowArea", TimeSpan.FromSeconds(10), null, null, null, null, () => Notif.donothing(), "OK",
+                NotificationTextTrimType.NoTrim, 2U, true, null, null, false);
         }
     }
 
@@ -2606,80 +2451,38 @@ public partial class Accounts : Page
 
             var automationTask = Task.Run(async () =>
             {
-                var riotval = string.Empty;
-                var attempts = 0;
-
-                while (string.IsNullOrEmpty(riotval))
+                var hwnd = await RiotUiLogin.WaitForLoginWindowAsync();
+                if (hwnd == IntPtr.Zero)
                 {
-                    if (Process.GetProcessesByName("Riot Client").Length != 0)
-                        riotval = "Riot Client";
-                    else if (Process.GetProcessesByName("RiotClientUx").Length != 0)
-                        riotval = "RiotClientUx";
-
-                    if (!string.IsNullOrEmpty(riotval) || attempts++ >= 80)
-                        break;
-
-                    await Task.Delay(200);
+                    DebugConsole.WriteLine("[Accounts] Riot Client window never appeared", ConsoleColor.Yellow);
+                    return;
                 }
 
-                if (string.IsNullOrEmpty(riotval))
-                    return;
+                await Task.Delay(3000);
 
+                var typed = 0;
                 while (!tokenDetectedTask.IsCompleted)
-                    try
+                {
+                    if (typed < 3)
                     {
-                        var app = Application.Attach(riotval);
-
-                        using (var automation = new UIA3Automation())
-                        {
-                            AutomationElement window = app.GetMainWindow(automation);
-                            var riotcontent =
-                                window.FindFirstDescendant(cf => cf.ByClassName("Chrome_RenderWidgetHostHWND"));
-
-                            var usernameField = riotcontent.FindFirstDescendant(cf => cf.ByAutomationId("username"))
-                                .AsTextBox();
-                            var passwordField = riotcontent.FindFirstDescendant(cf => cf.ByAutomationId("password"))
-                                .AsTextBox();
-                            var checkbox =
-                                riotcontent.FindFirstDescendant(cf => cf.ByControlType(ControlType.CheckBox));
-
-                            if (usernameField == null || passwordField == null || checkbox == null)
-                            {
-                                await Task.Delay(200);
-                                continue;
-                            }
-
-                            var siblings = riotcontent.FindAllChildren();
-                            var count = Array.IndexOf(siblings, checkbox) + 1;
-                            dynamic signInElement = null;
-                            while (siblings.Length >= count)
-                            {
-                                signInElement = siblings[count++].AsButton();
-                                if (signInElement != null && signInElement.ControlType == ControlType.Button)
-                                    break;
-                            }
-
-                            usernameField.Text = SelectedUsername;
-                            passwordField.Text = SelectedPassword;
-
-                            if (signInElement != null)
-                            {
-                                while (!signInElement.IsEnabled && !tokenDetectedTask.IsCompleted)
-                                    await Task.Delay(200);
-
-                                if (!tokenDetectedTask.IsCompleted)
-                                    signInElement.Invoke();
-                            }
-
-                            await Task.Delay(500);
-                        }
+                        DebugConsole.WriteLine($"[Accounts] Typing credentials for token capture (attempt {typed + 1})");
+                        if (await RiotUiLogin.EnterCredentialsAsync(SelectedUsername, SelectedPassword))
+                            typed++;
+                        else
+                            await Task.Delay(2000);
                     }
-                    catch (Exception ex)
+
+                    // give the proxy time to see the token before retyping;
+                    // after 3 attempts just wait (captcha may need the user)
+                    var waited = 0;
+                    while (!tokenDetectedTask.IsCompleted && waited < 20000)
                     {
-                        _logger.Warn(ex, "Transient error during login automation");
-                        DebugConsole.WriteLine($"[Accounts] Login automation retry: {ex.Message}", ConsoleColor.Yellow);
-                        await Task.Delay(200);
+                        await Task.Delay(500);
+                        waited += 500;
                     }
+
+                    if (!RiotUiLogin.RiotClientRunning) return;
+                }
             });
 
 

--- a/League_Account_Manager/views/ValorantAccounts.xaml.cs
+++ b/League_Account_Manager/views/ValorantAccounts.xaml.cs
@@ -431,234 +431,48 @@ public partial class ValorantAccounts : Page
             }
 
 
-            while (true)
+            var hwnd = await RiotUiLogin.WaitForLoginWindowAsync();
+            if (hwnd == IntPtr.Zero)
             {
-                if (Process.GetProcessesByName("Riot Client").Length != 0)
+                DebugConsole.WriteLine("[ValorantAccounts] Riot Client window never appeared", ConsoleColor.Yellow);
+                return;
+            }
+
+            // give the sign-in page time to render inside the window
+            await Task.Delay(4000);
+
+            var loggedIn = false;
+            for (var attempt = 1; attempt <= 3 && !loggedIn; attempt++)
+            {
+                DebugConsole.WriteLine($"[ValorantAccounts] Typing credentials (attempt {attempt})");
+                if (!await RiotUiLogin.EnterCredentialsAsync(SelectedUsername, SelectedPassword))
                 {
-                    riotval = "Riot Client";
-                    break;
+                    await Task.Delay(2000);
+                    continue;
                 }
 
-                if (Process.GetProcessesByName("RiotClientUx").Length != 0)
-                {
-                    riotval = "RiotClientUx";
-                    break;
-                }
+                loggedIn = await RiotUiLogin.WaitForAuthAsync(TimeSpan.FromSeconds(20));
+            }
 
-
-                Thread.Sleep(200);
-                num++;
-                if (num == 80)
+            // still not authenticated: a captcha or login error may need the user;
+            // keep waiting while the client is running instead of retyping over it
+            while (!loggedIn)
+            {
+                if (!RiotUiLogin.RiotClientRunning)
                 {
-                    DebugConsole.WriteLine("[ValorantAccounts] Timed out waiting for Riot client process",
+                    DebugConsole.WriteLine("[ValorantAccounts] Riot Client closed before login completed",
                         ConsoleColor.Yellow);
                     return;
                 }
+
+                loggedIn = await RiotUiLogin.WaitForAuthAsync(TimeSpan.FromSeconds(5));
             }
 
-            DebugConsole.WriteLine($"[ValorantAccounts] Attached to process: {riotval}");
-
-            var loginAttempts = 0;
-
-            while (true)
-                try
-                {
-                    var restartLogin = false;
-                    var cancelLogin = false;
-                    var app = Application.Attach(riotval);
-
-                    using (var automation = new UIA3Automation())
-                    {
-                        AutomationElement window = app.GetMainWindow(automation);
-                        var riotcontent =
-                            window.FindFirstDescendant(cf => cf.ByClassName("Chrome_RenderWidgetHostHWND"));
-
-
-                        var usernameField = riotcontent.FindFirstDescendant(cf => cf.ByAutomationId("username"))
-                            .AsTextBox();
-                        if (usernameField == null) throw new Exception("Username field not found");
-
-
-                        // Find the password field
-                        var passwordField = riotcontent.FindFirstDescendant(cf => cf.ByAutomationId("password"))
-                            .AsTextBox();
-                        if (passwordField == null) throw new Exception("Password field not found");
-
-
-                        var checkbox = riotcontent.FindFirstDescendant(cf => cf.ByControlType(ControlType.CheckBox));
-                        if (riotcontent == null) throw new Exception("Riot content not found");
-                        if (checkbox == null) throw new Exception("Checkbox field not found");
-
-                        var siblings = riotcontent.FindAllChildren();
-                        if (checkbox.Parent == null) throw new Exception("Checkbox parent not found");
-                        var count = Array.IndexOf(siblings, checkbox) + 1;
-                        if (siblings.Length <= count) throw new Exception("Not enough siblings found for the checkbox");
-                        dynamic signInElement = null;
-                        while (siblings.Length >= count)
-                        {
-                            signInElement = siblings[count++].AsButton();
-
-                            if (signInElement.ControlType != ControlType.Button) continue;
-                            break;
-                        }
-
-                        usernameField.Text = SelectedUsername;
-                        passwordField.Text = SelectedPassword;
-                        if (signInElement != null)
-                        {
-                            while (!signInElement.IsEnabled) Thread.Sleep(200);
-                            DebugConsole.WriteLine("[ValorantAccounts] Sign-in button enabled, invoking login");
-                            signInElement.Invoke();
-
-                            // brief pause to allow any login error tooltip to appear
-                            await Task.Delay(500);
-
-                            while (true)
-                            {
-                                try
-                                {
-                                    // look for a Tooltip with name "Login error" in the same window
-                                    var loginError = window.FindFirstDescendant(cf =>
-                                        cf.ByControlType(ControlType.ToolTip).And(cf.ByName("Login error")));
-                                    if (loginError != null)
-                                    {
-                                        loginAttempts++;
-                                        DebugConsole.WriteLine(
-                                            $"[ValorantAccounts] Login error tooltip detected (attempt {loginAttempts})",
-                                            ConsoleColor.Yellow);
-
-                                        var errorText = string.Empty;
-                                        try
-                                        {
-                                            errorText = loginError
-                                                .FindFirstDescendant(cf => cf.ByControlType(ControlType.Text)
-                                                    .And(cf.ByName(
-                                                        "Your login credentials don't match an account in our system.")))
-                                                ?.Name;
-                                        }
-                                        catch
-                                        {
-                                        }
-
-                                        if (string.IsNullOrWhiteSpace(errorText))
-                                        {
-                                            try
-                                            {
-                                                errorText = loginError.Name;
-                                            }
-                                            catch
-                                            {
-                                            }
-
-                                            if (string.IsNullOrWhiteSpace(errorText))
-                                                try
-                                                {
-                                                    errorText = loginError.Properties.Name.Value;
-                                                }
-                                                catch
-                                                {
-                                                }
-                                        }
-
-                                        var invalidCreds = !string.IsNullOrWhiteSpace(errorText) &&
-                                                           errorText.Contains(
-                                                               "Your login credentials don't match an account in our system.",
-                                                               StringComparison.OrdinalIgnoreCase);
-
-                                        if (invalidCreds)
-                                        {
-                                            // Mark account as invalid login
-                                            var existingNote = ActualAccountlists?.FindLast(x =>
-                                                x.username == SelectedUsername && x.password == SelectedPassword)?.note;
-                                            ActualAccountlists?.RemoveAll(x =>
-                                                x.username == SelectedUsername && x.password == SelectedPassword);
-                                            ActualAccountlists?.Add(new Utils.AccountList
-                                            {
-                                                username = SelectedUsername,
-                                                password = SelectedPassword,
-                                                riotID = "Invalid Login",
-                                                level = 0,
-                                                server = "INVALID",
-                                                be = 0,
-                                                rp = 0,
-                                                rank = "Invalid Login",
-                                                champions = "",
-                                                Champions = 0,
-                                                skins = "",
-                                                Skins = 0,
-                                                Loot = "",
-                                                Loots = 0,
-                                                rank2 = "Invalid Login",
-                                                note = existingNote
-                                            });
-
-                                            // persist immediately
-                                            await AccountFileStore.SaveAsync(AccountFileStore.GetAccountsFilePath(),
-                                                ActualAccountlists, config);
-
-                                            DebugConsole.WriteLine(
-                                                "[ValorantAccounts] Invalid login detected, account updated");
-                                            return; // pause/stop login processing
-                                        }
-
-                                        if (loginAttempts >= 3)
-                                        {
-                                            cancelLogin = true;
-                                            DebugConsole.WriteLine(
-                                                "[ValorantAccounts] Max login attempts reached, canceling login",
-                                                ConsoleColor.Yellow);
-                                            break;
-                                        }
-
-                                        restartLogin = true;
-                                        break;
-                                    }
-                                }
-                                catch
-                                {
-                                }
-
-                                var resp = await Lcu.Connector("riot", "get", "/eula/v1/agreement/acceptance", "");
-                                string status = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
-                                DebugConsole.WriteLine($"[Accounts] EULA status: {status}");
-                                if (status == "\"Accepted\"") break;
-                                if (status == "\"AcceptanceRequired\"")
-                                {
-                                    await Lcu.Connector("riot", "put", "/eula/v1/agreement/acceptance", "");
-                                    Thread.Sleep(200);
-                                }
-                                else
-                                {
-                                    Thread.Sleep(500);
-                                }
-                            }
-
-                            if (cancelLogin) return;
-
-                            if (restartLogin)
-                            {
-                                DebugConsole.WriteLine("[ValorantAccounts] Retrying login automation");
-                                await Task.Delay(500);
-                                continue;
-                            }
-
-                            DebugConsole.WriteLine("[ValorantAccounts] Login accepted, launching Valorant product");
-                            await Lcu.Connector("riot", "post",
-                                "/product-launcher/v1/products/valorant/patchlines/live", "");
-                            DebugConsole.WriteLine("[ValorantAccounts] Triggering Valorant account pull after login");
-                            OnPullDataClick(this, new RoutedEventArgs());
-                            break;
-                        }
-
-                        Thread.Sleep(500);
-                    }
-                }
-                catch (Exception ex)
-                {
-                    _logger.Warn(ex, "Transient error during login automation");
-                    DebugConsole.WriteLine($"[Accounts] Login automation retry: {ex.Message}", ConsoleColor.Yellow);
-                    Thread.Sleep(200);
-                }
+            DebugConsole.WriteLine("[ValorantAccounts] Login accepted, launching Valorant product");
+            await Lcu.Connector("riot", "post",
+                "/product-launcher/v1/products/valorant/patchlines/live", "");
+            DebugConsole.WriteLine("[ValorantAccounts] Triggering Valorant account pull after login");
+            OnPullDataClick(this, new RoutedEventArgs());
         }
         catch (Exception exception)
         {
@@ -1605,80 +1419,39 @@ public partial class ValorantAccounts : Page
 
             var automationTask = Task.Run(async () =>
             {
-                var riotval = string.Empty;
-                var attempts = 0;
-
-                while (string.IsNullOrEmpty(riotval))
+                var hwnd = await RiotUiLogin.WaitForLoginWindowAsync();
+                if (hwnd == IntPtr.Zero)
                 {
-                    if (Process.GetProcessesByName("Riot Client").Length != 0)
-                        riotval = "Riot Client";
-                    else if (Process.GetProcessesByName("RiotClientUx").Length != 0)
-                        riotval = "RiotClientUx";
-
-                    if (!string.IsNullOrEmpty(riotval) || attempts++ >= 80)
-                        break;
-
-                    await Task.Delay(200);
+                    DebugConsole.WriteLine("[ValorantAccounts] Riot Client window never appeared", ConsoleColor.Yellow);
+                    return;
                 }
 
-                if (string.IsNullOrEmpty(riotval))
-                    return;
+                await Task.Delay(3000);
 
+                var typed = 0;
                 while (!tokenDetectedTask.IsCompleted)
-                    try
+                {
+                    if (typed < 3)
                     {
-                        var app = Application.Attach(riotval);
-
-                        using (var automation = new UIA3Automation())
-                        {
-                            AutomationElement window = app.GetMainWindow(automation);
-                            var riotcontent =
-                                window.FindFirstDescendant(cf => cf.ByClassName("Chrome_RenderWidgetHostHWND"));
-
-                            var usernameField = riotcontent.FindFirstDescendant(cf => cf.ByAutomationId("username"))
-                                .AsTextBox();
-                            var passwordField = riotcontent.FindFirstDescendant(cf => cf.ByAutomationId("password"))
-                                .AsTextBox();
-                            var checkbox =
-                                riotcontent.FindFirstDescendant(cf => cf.ByControlType(ControlType.CheckBox));
-
-                            if (usernameField == null || passwordField == null || checkbox == null)
-                            {
-                                await Task.Delay(200);
-                                continue;
-                            }
-
-                            var siblings = riotcontent.FindAllChildren();
-                            var count = Array.IndexOf(siblings, checkbox) + 1;
-                            dynamic signInElement = null;
-                            while (siblings.Length >= count)
-                            {
-                                signInElement = siblings[count++].AsButton();
-                                if (signInElement != null && signInElement.ControlType == ControlType.Button)
-                                    break;
-                            }
-
-                            usernameField.Text = SelectedUsername;
-                            passwordField.Text = SelectedPassword;
-
-                            if (signInElement != null)
-                            {
-                                while (!signInElement.IsEnabled && !tokenDetectedTask.IsCompleted)
-                                    await Task.Delay(200);
-
-                                if (!tokenDetectedTask.IsCompleted)
-                                    signInElement.Invoke();
-                            }
-
-                            await Task.Delay(500);
-                        }
+                        DebugConsole.WriteLine(
+                            $"[ValorantAccounts] Typing credentials for token capture (attempt {typed + 1})");
+                        if (await RiotUiLogin.EnterCredentialsAsync(SelectedUsername, SelectedPassword))
+                            typed++;
+                        else
+                            await Task.Delay(2000);
                     }
-                    catch (Exception ex)
+
+                    // give the proxy time to see the token before retyping;
+                    // after 3 attempts just wait (captcha may need the user)
+                    var waited = 0;
+                    while (!tokenDetectedTask.IsCompleted && waited < 20000)
                     {
-                        _logger.Warn(ex, "Transient error during login automation");
-                        DebugConsole.WriteLine($"[Accounts] Login automation retry: {ex.Message}", ConsoleColor.Yellow);
-                        await Task.Delay(200);
+                        await Task.Delay(500);
+                        waited += 500;
                     }
+
+                    if (!RiotUiLogin.RiotClientRunning) return;
+                }
             });
 
 


### PR DESCRIPTION
## Problem

Since Riot Client v136, clicking Login opens the client but **no text is ever entered into the login boxes**.

Root cause: the new client no longer exposes a UI Automation tree. There is no `Chrome_RenderWidgetHostHWND` child window anymore, and no elements with the `username` / `password` automation ids — verified by dumping the UIA tree of a live v136 client (it contains only empty panes, zero Edit/Button/CheckBox elements, even after 30+ seconds of polling). Every login flow's `FindFirstDescendant(ByAutomationId(...))` therefore returns null and the surrounding retry loop spins silently forever.

A secondary bug: `Application.Attach("Riot Client")` attaches by process name, but CEF spawns ~8 processes all named "Riot Client" and only one owns the window, so `GetMainWindow` frequently hangs on a windowless subprocess.

## Fix

New shared helper `Misc/RiotUiLogin.cs` used by all four login flows (League login, Valorant login, both token-capture flows):

- resolves the Riot window **fresh on every attempt** — the client recreates its window during startup, so cached handles go stale
- brings the window to the foreground (`SetForegroundWindow` + `AttachThreadInput` handshake so Windows permits the switch)
- clicks the username/password fields at window-relative coordinates and types with **SendInput per-key scancode events** (`KEYEVENTF_SCANCODE` resolved through the active keyboard layout, real Shift presses around shifted characters, `KEYEVENTF_UNICODE` fallback only for characters the layout cannot produce) — indistinguishable from physical typing and independent of the accessibility layer
- submits with Enter, then confirms login by polling `/eula/v1/agreement/acceptance` on the local client API (accepting when required), retrying up to 3 times spaced 20s apart in case the page wasn't rendered yet
- if a captcha appears, stops retyping and waits for the user to solve it, then continues

Also: login errors (e.g. "Account not selected") now show a visible notification instead of being silently swallowed into the log.

## Known limitation

Invalid-credential detection relied on reading a UIA tooltip ("Login error") that the new client no longer exposes, so wrong passwords now sit at the login screen instead of auto-marking the account "Invalid Login". Happy to discuss alternatives (e.g. timeout-based marking).

## Testing

Verified end-to-end on Windows 11 against Riot Client v136.0.3: account selected → Login clicked → credentials typed on attempt 1 → EULA confirmed → League client launched and reached summoner-ready → account stats pulled. Token flows compile and share the same typing path.
