### PR TITLE
Add AutoMuteAll: automatically mute all teammates in champ select

### DIFF
--- a/League_Account_Manager/views/Autolobby.xaml
+++ b/League_Account_Manager/views/Autolobby.xaml
@@ -18,6 +18,10 @@
         <Button Content="Enable AutoAcceptQueue" Margin="10,10,0,0" VerticalAlignment="Top"
                 Click="OnToggleAutoAcceptClick"
                 Height="67" Width="300" />
+        <Button Content="Enable AutoMuteAll" Margin="10,82,0,0" VerticalAlignment="Top"
+                Click="OnToggleAutoMuteClick"
+                Height="67" Width="300"
+                ToolTip="Mutes every teammate in champion select chat automatically" />
         <Button Content="Enable AutoAcceptPick" Margin="317,10,0,0" VerticalAlignment="Top"
                 Click="OnToggleAutoPickClick"
                 Height="67" Width="290" />

--- a/League_Account_Manager/views/Autolobby.xaml.cs
+++ b/League_Account_Manager/views/Autolobby.xaml.cs
@@ -323,6 +323,11 @@ public partial class Autolobby : Page
         ToggleTask("AutoAcceptMessage", StartAutoMessageTask, sender);
     }
 
+    private void OnToggleAutoMuteClick(object sender, RoutedEventArgs e)
+    {
+        ToggleTask("AutoMuteAll", StartAutoMuteTask, sender);
+    }
+
     // =====================================================
     // AUTO ACCEPT
     // =====================================================
@@ -344,6 +349,114 @@ public partial class Autolobby : Page
             }
 
             await Task.Delay(3000, ct);
+        }
+    }
+
+    // =====================================================
+    // AUTO MUTE TEAMMATES
+    // =====================================================
+
+    private readonly HashSet<string> _mutedThisChampSelect = new();
+    private string _muteSessionKey = string.Empty;
+
+    private async Task StartAutoMuteTask(CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                var session = champselectJObject;
+                if (session != null &&
+                    session.TryGetValue("myTeam", out var myTeamToken) &&
+                    myTeamToken is JArray myTeam)
+                {
+                    // new champ select -> forget who we muted last time
+                    var sessionKey = session["gameId"]?.ToString() ?? "";
+                    if (sessionKey != _muteSessionKey)
+                    {
+                        _muteSessionKey = sessionKey;
+                        _mutedThisChampSelect.Clear();
+                    }
+
+                    // authoritative muted list, so we never toggle someone back off
+                    var alreadyMuted = new HashSet<string>();
+                    try
+                    {
+                        var mutedResp = await Lcu.Connector("league", "get",
+                            "/lol-champ-select/v1/muted-players", "");
+                        var mutedBody = await mutedResp.Content.ReadAsStringAsync().ConfigureAwait(false);
+                        foreach (var m in JArray.Parse(mutedBody))
+                        {
+                            var p = m["puuid"]?.ToString();
+                            var op = m["obfuscatedPuuid"]?.ToString();
+                            if (!string.IsNullOrEmpty(p)) alreadyMuted.Add(p);
+                            if (!string.IsNullOrEmpty(op)) alreadyMuted.Add(op);
+                        }
+                    }
+                    catch
+                    {
+                        // list unavailable outside champ select; fall back to local tracking
+                    }
+
+                    var localCellId = session["localPlayerCellId"]?.ToString();
+
+                    foreach (var t in myTeam)
+                    {
+                        if (t is not JObject member)
+                            continue;
+                        if (member["cellId"]?.ToString() == localCellId)
+                            continue; // never mute ourselves
+
+                        var puuid = member["puuid"]?.ToString() ?? "";
+                        var obfuscatedPuuid = member["obfuscatedPuuid"]?.ToString() ?? "";
+                        var summonerId = member["summonerId"]?.Value<long>() ?? 0;
+
+                        // bots have no identity to mute
+                        if (string.IsNullOrEmpty(puuid) && string.IsNullOrEmpty(obfuscatedPuuid) && summonerId == 0)
+                            continue;
+
+                        var key = !string.IsNullOrEmpty(puuid) ? puuid
+                            : !string.IsNullOrEmpty(obfuscatedPuuid) ? obfuscatedPuuid
+                            : "cell:" + member["cellId"];
+
+                        if (_mutedThisChampSelect.Contains(key))
+                            continue;
+                        if (alreadyMuted.Contains(puuid) || alreadyMuted.Contains(obfuscatedPuuid))
+                        {
+                            _mutedThisChampSelect.Add(key);
+                            continue;
+                        }
+
+                        var body = new JObject
+                        {
+                            ["puuid"] = puuid,
+                            ["summonerId"] = summonerId,
+                            ["obfuscatedPuuid"] = obfuscatedPuuid,
+                            ["obfuscatedSummonerId"] = member["obfuscatedSummonerId"]?.Value<long>() ?? 0
+                        };
+                        var resp = await Lcu.Connector("league", "post",
+                            "/lol-champ-select/v1/toggle-player-muted",
+                            body.ToString(Newtonsoft.Json.Formatting.None));
+
+                        if (resp != null && resp.IsSuccessStatusCode)
+                        {
+                            _mutedThisChampSelect.Add(key);
+                            Log($"AutoMute: muted teammate in cell {member["cellId"]}");
+                        }
+                        else
+                        {
+                            Log($"AutoMute: mute request failed for cell {member["cellId"]} " +
+                                $"({resp?.StatusCode.ToString() ?? "no response"})");
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Error in AutoMute");
+            }
+
+            await Task.Delay(2000, ct);
         }
     }
 


### PR DESCRIPTION
## Summary

Adds an **Enable AutoMuteAll** toggle to the Auto Champ select page that automatically mutes every teammate in champion select chat.

## How it works

- While enabled, a background task polls the champ select session (same 2s cadence as the other Auto Champ select features).
- For each player on your team it calls `POST /lol-champ-select/v1/toggle-player-muted` with the full `{puuid, summonerId, obfuscatedPuuid, obfuscatedSummonerId}` body, so it also works in queues where teammates are obfuscated.
- It never mutes yourself (`localPlayerCellId` guard) and skips bots (no puuid/summonerId to mute).
- Because Riot's endpoint is a *toggle*, the task first consults `GET /lol-champ-select/v1/muted-players` and tracks who it already muted per champ select (reset on `gameId` change). This guarantees it never accidentally *unmutes* anyone, and manual unmutes by the user are respected instead of being re-applied.

## Notes

- Mutes champ-select chat only; in-game chat/ping muting is a different system.
- Uses the existing `ToggleTask` infrastructure on the Autolobby page, so it composes with AutoAcceptQueue/Pick/Ban/Message.

<img width="1918" height="1059" alt="image" src="https://github.com/user-attachments/assets/8822a5f1-8736-4eaf-b673-13bfc50994c1" />

